### PR TITLE
Return downloaded videos result in `download_videos` command

### DIFF
--- a/tapo-cli.py
+++ b/tapo-cli.py
@@ -318,6 +318,7 @@ def download_videos(days, path, overwrite):
     end_time = datetime.datetime.utcfromtimestamp(end_unixtime).strftime('%Y-%m-%d 00:00:00')
     start_time = datetime.datetime.utcfromtimestamp(start_unixtime).strftime('%Y-%m-%d 00:00:00')
 
+    result = []
     endpoint = '/v2/videos/list'
     for dev in devs['deviceList']:
         params = 'deviceId=' + dev['deviceId'] + '&page=0&pageSize=3000&order=desc&startTime=' + start_time + '&endTime=' + end_time
@@ -342,9 +343,12 @@ def download_videos(days, path, overwrite):
                 file_name = video['eventLocalTime'].replace(':','-') + '.mp4'
                 if os.path.exists(file_path + file_name) and overwrite == 0:
                     print('Already exists ' + file_path + file_name)    
+                    result.append({'file': file_path + file_name, 'device': dev['alias'], 'new_video': False, 'video': video})
                 else:
                     print('Downloading to ' + file_path + file_name)
                     download(url, key_b64, file_path, file_name)
+                    result.append({'file': file_path + file_name, 'device': dev['alias'], 'new_video': True, 'video': video})
+    return result
 
 tapo.add_command(login, 'login')
 tapo.add_command(account_info, 'list-account-info')


### PR DESCRIPTION
I am using Tapo CLI for periodically pulling videos from my Tapo cloud account and uploading the videos to local ZoneMinder installation where I keep the central repo of all security cam footage.

I modified the `download_videos` command to return the list of all (potentially) downloaded videos so that the command can be called from other Python modules (using `download_videos.callback(days, path, overwrite)` Click hack) and, consequently, videos processed directly without having to resort to filesystem scanning, storing "uploaded yes/no" flags, etc. The command returns the list of processed videos w/ the following attributes:
- `file` absolute path of the downloaded video file
- `device` Tapo camera name
- `new_video` boolean flag indicating whether the video has been downloaded or skipped (when `overwrite` is set to 0)
- `video` video metadata from Tapo cloud

P.S. Thank you very much for sharing this great CLI tool! :100: