### PR TITLE
Improve list/download robustness (pagination, retries, per-camera summary)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 urllib3
 datetime
 pycryptodome
+Crypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests
 urllib3
 datetime
 pycryptodome
-Crypto

--- a/tapo-cli.py
+++ b/tapo-cli.py
@@ -140,7 +140,7 @@ def login(username, password):
     """Authenticates a user towards the TP-Link Tapo Cloud."""
     terminal_uuid = str(uuid.uuid1()).replace('-','').upper()
 
-    url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/login'
+    url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/login'
     content = {"appType":"TP-Link_Tapo_Android","appVersion":"2.12.705","cloudPassword":password,"cloudUserName":username,"platform":"Android 12","refreshTokenNeeded":False,"terminalMeta":"1","terminalName":"Tapo CLI","terminalUUID":terminal_uuid}
     content = json.dumps(content)
     res = post(url, content, headers_post(content, '/api/v2/account/login'))
@@ -152,7 +152,7 @@ def login(username, password):
     # Login but with extra steps
     if 'MFAProcessId' in config:
         mfa_process_id = res['result']['MFAProcessId']
-        url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/getPushVC4TerminalMFA'
+        url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/getPushVC4TerminalMFA'
         content = {"appType":"TP-Link_Tapo_Android","cloudPassword":password,"cloudUserName":username,"terminalUUID":terminal_uuid}
         content = json.dumps(content)
         res = post(url, content, headers_post(content, '/api/v2/account/getPushVC4TerminalMFA'))
@@ -162,7 +162,7 @@ def login(username, password):
         print('Check your Tapo App for the MFA code!')
         mfa_code = str(input('MFA Code (no spaces or dashes): '))
     
-        url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/checkMFACodeAndLogin'
+        url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/checkMFACodeAndLogin'
         content = {"appType":"TP-Link_Tapo_Android","cloudUserName":username,"code":mfa_code,"MFAProcessId":mfa_process_id,"MFAType":1,"terminalBindEnabled":True}
         content = json.dumps(content)
         res = post(url, content, headers_post(content, '/api/v2/account/checkMFACodeAndLogin'))

--- a/tapo-cli.py
+++ b/tapo-cli.py
@@ -322,17 +322,14 @@ def list_videos(days):
     start_time = datetime.datetime.fromtimestamp(start_unixtime, datetime.timezone.utc).strftime('%Y-%m-%d 00:00:00')
 
     endpoint = '/v2/videos/list'
-    page_size = 1000  # was 3000
+    page_size = 1000
 
     for dev in devs['deviceList']:
         print(f"\nListing videos for {dev['alias']}:")
 
         page = 0
-        total_printed = 0
 
         while True:
-            print("page: " + str(page))
-
             params = (
                 'deviceId=' + dev['deviceId'] +
                 '&page=' + str(page) +
@@ -351,15 +348,13 @@ def list_videos(days):
             entries = videos.get('index', [])
             if not entries:
                 # No more videos on this page -> we are done
-                if total_printed == 0:
-                    print("  No videos found.")
                 break
 
             # Print timestamps for this page
             for video in entries:
-            #     print(video['eventLocalTime'], end=", ")
-                total_printed += 1
-            print(len(entries))
+                print(video['eventLocalTime'], end=", ")
+                #print(video['video'][0]['uri']) # This will print URLs to the videos if you want to download them using another tool, but don't forget to get the AES key from video['video'][0]['decryptionInfo']['key']
+
             # If we got fewer than page_size entries, that was the last page
             if len(entries) < page_size:
                 print("")  # newline after the comma-separated list
@@ -389,7 +384,7 @@ def download_videos(days, path, overwrite):
 
     result = []
     endpoint = '/v2/videos/list'
-    page_size = 1000  # was 3000
+    page_size = 1000
 
     # stats per camera
     stats = {}
@@ -422,7 +417,6 @@ def download_videos(days, path, overwrite):
             
             if not entries:
                 # No more videos on this page -> we are done
-                print("  No videos found.")
                 break
 
             for video in entries:


### PR DESCRIPTION
### **Improve `list-videos` and `download-videos` reliability (pagination, retries, per-camera summary)**

#### Summary

This PR improves the reliability and usability of the `list-videos` and `download-videos` commands, especially when downloading a large number of videos (e.g., last 30 days) where the Tapo API may intermittently fail.

#### Changes

* **Pagination for `/v2/videos/list`**

  * Reduces `pageSize` from 3000 → 1000 to avoid intermittent HTTP 500 errors from the Tapo cloud API
  * Iterates pages until no more results are returned, ensuring **all** videos are processed

* **Resilient downloads with retry logic**

  * Retries failed downloads up to 3 times on `ChunkedEncodingError` / `ConnectionError`
  * Continues to the next file on repeated failure instead of aborting the whole script

* **Per-camera result summary**

  * Shows, for each camera:

    * Number of successfully downloaded videos
    * Number of videos skipped because they already exist (`--overwrite 0`)
    * Number of downloads that failed after retrying
  * Helps users quickly validate the outcome and rerun if needed

* **Fixed UTC deprecation warning**

  * Replaces `datetime.datetime.utcfromtimestamp()` with `datetime.datetime.fromtimestamp(..., datetime.timezone.utc)`
  * Uses timezone-aware datetimes to prevent warnings in Python 3.12+

#### Impact

These updates significantly improve the stability of large download operations from the Tapo Cloud, especially over slower or inconsistent network connections. The CLI now:

* Can survive transient network failures
* Downloads all available recordings correctly
* Provides clear feedback to the user

#### Compatibility

* No breaking changes to existing command usage
* Fully backwards-compatible with current Tapo CLI workflows