### PR TITLE
Fix login failure caused by incorrect URL

### DIFF
--- a/tapo-cli.py
+++ b/tapo-cli.py
@@ -140,7 +140,7 @@ def login(username, password):
     """Authenticates a user towards the TP-Link Tapo Cloud."""
     terminal_uuid = str(uuid.uuid1()).replace('-','').upper()
 
-    url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/login'
+    url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/login'
     content = {"appType":"TP-Link_Tapo_Android","appVersion":"2.12.705","cloudPassword":password,"cloudUserName":username,"platform":"Android 12","refreshTokenNeeded":False,"terminalMeta":"1","terminalName":"Tapo CLI","terminalUUID":terminal_uuid}
     content = json.dumps(content)
     res = post(url, content, headers_post(content, '/api/v2/account/login'))
@@ -152,7 +152,7 @@ def login(username, password):
     # Login but with extra steps
     if 'MFAProcessId' in config:
         mfa_process_id = res['result']['MFAProcessId']
-        url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/getPushVC4TerminalMFA'
+        url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/getPushVC4TerminalMFA'
         content = {"appType":"TP-Link_Tapo_Android","cloudPassword":password,"cloudUserName":username,"terminalUUID":terminal_uuid}
         content = json.dumps(content)
         res = post(url, content, headers_post(content, '/api/v2/account/getPushVC4TerminalMFA'))
@@ -162,7 +162,7 @@ def login(username, password):
         print('Check your Tapo App for the MFA code!')
         mfa_code = str(input('MFA Code (no spaces or dashes): '))
     
-        url = 'https://n-wap-gw.tplinkcloud.com/api/v2/account/checkMFACodeAndLogin'
+        url = 'https://n-euw1-wap-gw.tplinkcloud.com/api/v2/account/checkMFACodeAndLogin'
         content = {"appType":"TP-Link_Tapo_Android","cloudUserName":username,"code":mfa_code,"MFAProcessId":mfa_process_id,"MFAType":1,"terminalBindEnabled":True}
         content = json.dumps(content)
         res = post(url, content, headers_post(content, '/api/v2/account/checkMFACodeAndLogin'))


### PR DESCRIPTION
Fixes login failures returning errorMsg: "Incorrect service entry address" by updating hard-coded authentication endpoints to use the correct regional Tapo gateway.

Some regions (including EUW1) no longer accept requests to the generic n-wap-gw.tplinkcloud.com hostname, causing authentication to fail even with valid credentials.

A future enhancement could dynamically derive the region from the accountApiUrl response and build the correct gateway automatically instead of hardcoding EUW1.